### PR TITLE
Support cref vref and comma seperated

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -5,8 +5,8 @@ CiteView = require './cite-view'
 module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
-    refRex: /\\(ref|eqref|[cCvV]ref){$/
-    citeRex: /\\(cite|textcite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?{$/
+    refRex: /\\(ref|eqref|[cCvV]ref)({|{[^}]+,)$/
+    citeRex: /\\(cite|textcite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable
       @disposables.add @editor.onDidChangeTitle => @subscribeBuffer()

--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -5,7 +5,7 @@ CiteView = require './cite-view'
 module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
-    refRex: /\\(ref|eqref|cref){$/
+    refRex: /\\(ref|eqref|[cCvV]ref){$/
     citeRex: /\\(cite|textcite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?{$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable


### PR DESCRIPTION
I would like to prose these changes for addition they enable the following:
Capitalised version of Cref
The varioref command vref 
The capitalised Vref (requires latex package cleveref).
Comma separated citations such as \cite{Frost:2009,Charles:2010}.
Additionally comma separated references \cref{tab1,tab2} (requires latex package cleveref).
