### PR TITLE
Resolve issue #18 https://github.com/Focus/latexer/issues/18

### DIFF
--- a/lib/cite-view.coffee
+++ b/lib/cite-view.coffee
@@ -51,14 +51,17 @@ class CiteView extends SelectListView
     cites
 
   getBibFiles: ->
-    basePath = @editor.getPath()
-    if basePath.lastIndexOf("/") isnt -1
-      basePath = basePath.substring 0, basePath.lastIndexOf("/")
+    editor = atom.workspace.getActivePaneItem()
+    file = editor?.buffer?.file
+    basePath = file?.path
+    activePaneItemPath = basePath
+    if basePath.lastIndexOf(pathModule.sep) isnt -1
+      basePath = basePath.substring 0, basePath.lastIndexOf(pathModule.sep)
     bibFiles = @getBibFileFromText(@editor.getText())
     if bibFiles == null or bibFiles.length == 0
       texRootRex = /%!TEX root = (.+)/g
       while(match = texRootRex.exec(@editor.getText()))
-        absolutFilePath = FindLabels.getAbsolutePath(@editor.getPath(), match[1])
+        absolutFilePath = FindLabels.getAbsolutePath(activePaneItemPath,match[1])
         basePath = pathModule.dirname(absolutFilePath)
         try
           text = fs.readFileSync(absolutFilePath).toString()

--- a/lib/find-labels.coffee
+++ b/lib/find-labels.coffee
@@ -23,6 +23,6 @@ FindLabels =
     @getLabelsByText(text, file)
 
   getAbsolutePath: (file, relativePath) ->
-    if (ind = file.lastIndexOf("/")) isnt file.length
+    if (ind = file.lastIndexOf(path.sep)) isnt file.length
       file = file.substring(0,ind)
     path.resolve(file, relativePath)

--- a/lib/label-view.coffee
+++ b/lib/label-view.coffee
@@ -14,17 +14,19 @@ class LabelView extends SelectListView
   show: (editor) ->
     return unless editor?
     @editor = editor
+    file = editor?.buffer?.file
+    basePath = file?.path
     texRootRex = /%!TEX root = (.+)/g
     while(match = texRootRex.exec(@editor.getText()))
-      absolutFilePath = FindLabels.getAbsolutePath(@editor.getPath(), match[1])
-      try 
+      absolutFilePath = FindLabels.getAbsolutePath(basePath,match[1])
+      try
         text = fs.readFileSync(absolutFilePath).toString()
         labels = FindLabels.getLabelsByText(text, absolutFilePath)
       catch error
         atom.notifications.addError('could not load content of '+ absolutFilePath, { dismissable: true })
         console.log(error)
     if labels == undefined or labels.length == 0
-      labels = FindLabels.getLabelsByText(@editor.getText(), @editor.getPath())
+      labels = FindLabels.getLabelsByText(@editor.getText(), basePath)
     @setItems(labels)
     @panel ?= atom.workspace.addModalPanel(item: this)
     @panel.show()
@@ -47,7 +49,7 @@ class LabelView extends SelectListView
     @editor.insertText label
     @restoreFocus()
     @hide()
-    
+
   cancel: ->
     super
     @hide()

--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -6,7 +6,7 @@ module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
     refRex: /\\(ref|eqref|[cCvV]ref)({|{[^}]+,)$/
-    citeRex: /\\(cite|textcite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
+    citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable
       @disposables.add @editor.onDidChangeTitle => @subscribeBuffer()


### PR DESCRIPTION
Replaced hard coded file path separators with path.sep.
Removed deprecated usage of @editor.getPath by instead using the active pane file path.
