### PR TITLE
Generalized refRex to include \nameref etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Generalized \ref matching to include any control sequence that ends in `ref`
+
 ## 0.2.5
 * Added support for searching citations by different parameters
 * Added support for comma seperated citations/references

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Features
 ####Reference autocompletion
   ![Autocompletion of references](https://github.com/Focus/latexer/raw/master/screenshots/ref.gif)
 Triggers:
-  * Typing in `\ref{` or `\eqref{`
-  * Deleting anything so that the left of the cursor reads `\ref{` or `\eqref{`, e.g. deleting the word 'something' from `\ref{something}`
+  * Typing in `\ref{`, `\eqref{` or any control sequences that ends in `ref{`
+  * Deleting anything so that the left of the cursor reads `\ref{`, `\eqref{`, and the like. E.g. deleting the word 'something' from `\pageref{something}`
 
 
 ####Bibliography autocompletion

--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -5,7 +5,7 @@ CiteView = require './cite-view'
 module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
-    refRex: /\\(ref|eqref|[cCvV]ref)({|{[^}]+,)$/
+    refRex: /\\\w*ref({|{[^}]+,)$/
     citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable


### PR DESCRIPTION
Generalized the ref catching regular expression to match
all TeX control sequences that end in ref. So this will
match \nameref, \fullref, \pageref, etc
