### PR TITLE
Fix #33

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -5,6 +5,7 @@ CiteView = require './cite-view'
 module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
+    mathRex: /(\\+)\[/
     refRex: /\\\w*ref({|{[^}]+,)$/
     citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
@@ -49,18 +50,19 @@ module.exports =
       #If it does, try to find the closing item, and if that doesn't exist put it in.
       else if pos[0]>1
         previousLine = @editor.lineTextForBufferRow(pos[0]-1)
-        if (match = @beginRex.exec(previousLine)) or (match = /\\\[\h*?$/.exec(previousLine))
-          lineCount = @editor.getLineCount()
-          remainingText = @editor.getTextInBufferRange([[pos[0],0],[lineCount+1,0]])
-          if match[0] is "\\["
-            beginText = "\\["
-            endText = "\\]"
-          else
-            beginText = "\\begin{#{match[1]}}"
-            endText = "\\end{#{match[1]}}"
-          remainingOnPrevLine = previousLine.substring(previousLine.indexOf(beginText))
-          return if remainingOnPrevLine.indexOf(endText) isnt -1
-          if (not remainingText?) or (remainingText.indexOf(endText) < 0) or ((remainingText.indexOf(beginText) < remainingText.indexOf(endText)) and (remainingText.indexOf(beginText) > 0))
-            @editor.insertText "\n"
-            @editor.insertText endText
-            @editor.moveUp 1
+        if (match = @beginRex.exec(previousLine))
+          beginText = "\\begin{#{match[1]}}"
+          endText = "\\end{#{match[1]}}"
+        else if (match = @mathRex.exec(previousLine)) and match[1].length % 2
+          beginText = "\\["
+          endText = "\\]"
+        else
+          return
+        lineCount = @editor.getLineCount()
+        remainingText = @editor.getTextInBufferRange([[pos[0],0],[lineCount+1,0]])
+        remainingOnPrevLine = previousLine.substring(previousLine.indexOf(beginText))
+        return if remainingOnPrevLine.indexOf(endText) isnt -1
+        if (not remainingText?) or (remainingText.indexOf(endText) < 0) or ((remainingText.indexOf(beginText) < remainingText.indexOf(endText)) and (remainingText.indexOf(beginText) > 0))
+          @editor.insertText "\n"
+          @editor.insertText endText
+          @editor.moveUp 1


### PR DESCRIPTION
`\[` is only matched if it is not preceded with an even number of backslashes.
If a match is found, it is closed with `\]`, not `\end{undefined}`
