### PR TITLE
Add theoremref support

### DIFF
--- a/lib/find-labels.coffee
+++ b/lib/find-labels.coffee
@@ -5,7 +5,7 @@ path = require 'path'
 module.exports =
 FindLabels =
   getLabelsByText: (text, file = "") ->
-    labelRex = /\\label{([^}]+)}/g
+    labelRex = /\\(?:th)label{([^}]+)}/g
     matches = []
     while (match = labelRex.exec(text))
       matches.push {label: match[1]}


### PR DESCRIPTION
This allows the package to find labels set by the \thlabel command from the theoremref package.
