### PR TITLE
Added a feature to look for .bib files in designated directories.

### DIFF
--- a/lib/cite-view.coffee
+++ b/lib/cite-view.coffee
@@ -75,6 +75,8 @@ class CiteView extends SelectListView
     basePath = basePath + pathModule.sep
     for bfpath in bibFiles
       result = result.concat(FindLabels.getAbsolutePath(basePath, bfpath) )
+      for bibDir in atom.config.get("latexer.directories_to_search_bib_in")
+        result = result.concat(FindLabels.getAbsolutePath(bibDir, bfpath) )
     result
 
   getBibFileFromText: (text) ->

--- a/lib/latexer.coffee
+++ b/lib/latexer.coffee
@@ -12,6 +12,12 @@ module.exports = Latexer =
       items:
         type: "string"
 
+    directories_to_search_bib_in:
+      type: "array"
+      default: ["C:\\texlive\\texmf-local\\bibtex\\bib\\"]
+      items:
+        type: "string"
+
     autocomplete_environments:
       type: "boolean"
       default: true

--- a/lib/latexer.coffee
+++ b/lib/latexer.coffee
@@ -14,7 +14,7 @@ module.exports = Latexer =
 
     directories_to_search_bib_in:
       type: "array"
-      default: ["C:\\texlive\\texmf-local\\bibtex\\bib\\"]
+      default: []
       items:
         type: "string"
 


### PR DESCRIPTION
Thank you for the cool package!

As I have my .bib file automatically generated by a bibliography manager and it's not located in the same directory as source files, I want latexer to search specified directories for the .bib file. So I added some codes to implement this feature. Summary of the changes is as follows:
- Added a config item to ask the directories to look for .bib files in
- Added lines in `getBibFiles()` to add to `result` array possible .bib files in the specified directories

Please merge them if you are happy to.
