### PR TITLE
add support for \crefrange and its friends

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -6,7 +6,7 @@ module.exports =
   class LatexerHook
     beginRex: /\\begin{([^}]+)}/
     mathRex: /(\\+)\[/
-    refRex: /\\\w*ref({|{[^}]+,)$/
+    refRex: /\\(\w*ref({|{[^}]+,)|[cC](page)?refrange({[^,}]*})?{)$/
     citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable


### PR DESCRIPTION
This PR adds support for completion in `\crefrange`, `\Crefrange`, `\cpagerefrange` and `\Cpagerefrange` from [`cleveref`](http://tug.ctan.org/macros/latex2e/contrib/cleveref/cleveref.pdf#section.4) package. Unlike other reference commands, these commands have two arguments, both of which are label keys, and completion in the second argument is also implemented.

![2016-07-17 17 33 40](https://cloud.githubusercontent.com/assets/13291527/16899619/67696898-4c45-11e6-93fa-6647cde2ac1a.png)
![2016-07-17 17 34 21](https://cloud.githubusercontent.com/assets/13291527/16899621/7328b170-4c45-11e6-8e85-4235bef5cd38.png)

As stated in #43, I had a trouble with loading my forked package. However, when I modified `apm`-installed package's `lib/latexer-hook.coffee` in the same way as this PR, this new feature functioned as I intended. So it will be applicable to the upstream version when the issue mentioned above is settled.
