### PR TITLE
Bibliography autocompletion enhancement

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -7,10 +7,7 @@ module.exports =
     beginRex: /\\begin{([^}]+)}/
     mathRex: /(\\+)\[/
     refRex: /\\\w*ref({|{[^}]+,)$/
-    # Enhance the reference autocompletion trigger by typing in any control sequences
-    # that ends in cite{, citet{, citet*{, citep{ or citep*{
     citeRex: /\\\w*(cite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
-    # citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable
       @disposables.add @editor.onDidChangeTitle => @subscribeBuffer()

--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -7,7 +7,10 @@ module.exports =
     beginRex: /\\begin{([^}]+)}/
     mathRex: /(\\+)\[/
     refRex: /\\\w*ref({|{[^}]+,)$/
-    citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
+    # Enhance the reference autocompletion trigger by typing in any control sequences
+    # that ends in cite{, citet{, citet*{, citep{ or citep*{
+    citeRex: /\\\w*(cite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
+    # citeRex: /\\(cite|textcite|onlinecite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable
       @disposables.add @editor.onDidChangeTitle => @subscribeBuffer()


### PR DESCRIPTION
Enhance the reference autocompletion trigger by typing in any control
sequences that ends in cite{, citet{, citet*{, citep{ or citep*{

I changed the regular expression within the "latexer-hook.coffee" on this commit. Although I don't know coffee or regular expression at all, these changes seem work pretty well. In case of other unexpected exceptions, please review it.

Thanks a lot for you and your package!
