### PR TITLE
support Knitr/Sweave files (.Rnw/.Snw)

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -30,7 +30,7 @@ module.exports =
       @unsubscribeBuffer()
       return unless @editor?
       title = @editor?.getTitle()
-      return unless title? and title.match(/\.tex$/)
+      return unless title? and title.match(/\.tex|[rs]nw$/i)
       @buffer = @editor.getBuffer()
       @disposableBuffer = @buffer.onDidStopChanging => @editorHook()
 


### PR DESCRIPTION
Add autocomplete support for Knitr (.Rnw or .rnw) and Sweave (.Snw or .snw) tex files.

related: https://github.com/thomasjo/atom-latex/pull/254
