### PR TITLE
Correct FindLabels.getLabels semantics

### DIFF
--- a/lib/find-labels.coffee
+++ b/lib/find-labels.coffee
@@ -12,7 +12,8 @@ FindLabels =
     return matches unless baseFile?
     inputRex = /\\(input|include){([^}]+)}/g
     while (match = inputRex.exec(text))
-      matches = matches.concat(@getLabels(@getAbsolutePath(baseFile, match[2]), baseFile))
+      matches = matches.concat(
+        @getLabels(@getAbsolutePath(baseFile, match[2]), baseFile))
     matches
 
   getLabels: (file, baseFile) ->

--- a/lib/find-labels.coffee
+++ b/lib/find-labels.coffee
@@ -4,24 +4,24 @@ path = require 'path'
 
 module.exports =
 FindLabels =
-  getLabelsByText: (text, file = "") ->
+  getLabelsByText: (text, baseFile = "") ->
     labelRex = /\\(?:th)?label{([^}]+)}/g
     matches = []
     while (match = labelRex.exec(text))
       matches.push {label: match[1]}
-    return matches unless file?
+    return matches unless baseFile?
     inputRex = /\\(input|include){([^}]+)}/g
     while (match = inputRex.exec(text))
-      matches = matches.concat(@getLabels(@getAbsolutePath(file, match[2])))
+      matches = matches.concat(@getLabels(@getAbsolutePath(baseFile, match[2]), baseFile))
     matches
 
-  getLabels: (file) ->
+  getLabels: (file, baseFile) ->
     #if file is not there try add possible extensions
     if not fsPlus.isFileSync(file)
       file = fsPlus.resolveExtension(file, ['tex'])
     return [] unless fsPlus.isFileSync(file)
     text = fs.readFileSync(file).toString()
-    @getLabelsByText(text, file)
+    @getLabelsByText(text, baseFile)
 
   getAbsolutePath: (file, relativePath) ->
     if (ind = file.lastIndexOf(path.sep)) isnt file.length


### PR DESCRIPTION
This fixes not finding labels from files included from the root file.

Latex's input and include commands determine the file to read based on
the main file of the document.
"getLabels" was incorrectly determining paths to inputted/included files
based on the current file.

Related issue; #41 