### PR TITLE
Format cite-view list externally and include bibtex key

### DIFF
--- a/lib/cite-view.coffee
+++ b/lib/cite-view.coffee
@@ -33,8 +33,11 @@ class CiteView extends SelectListView
 
   viewForItem: ({title, key, author}) ->
     """
-    <li><span style='display:block;'>#{title}</span>
-    <span style='display:block;font-size:xx-small;'>#{author}</span></li>
+      <li>
+        <span class='cite-view-title'>#{title}</span>
+        <span class='cite-view-key'>#{key}</span>
+        <span class='cite-view-author'>#{author}</span>
+      </li>
     """
 
   hide: ->

--- a/styles/latexer.less
+++ b/styles/latexer.less
@@ -1,0 +1,18 @@
+.cite-view-title {
+  display: block;
+}
+
+.cite-view-key {
+  font-size: xx-small;
+}
+
+.cite-view-key::before {
+  content:"["
+}
+.cite-view-key::after {
+  content:"]"
+}
+
+.cite-view-author {
+  font-size: xx-small;
+}


### PR DESCRIPTION
Currently, the bibtex key cannot be displayed in the citation selection list. This patch adds a `<span>` item for the key and individual style classes for title, author and key. It further adds a default style sheet that restores the current layout (up to additionally showing the bibtex key). 

The user can now customize this style in terms of the `styles.less` configuration file. For example, the bibtex key can be hidden by including `.cite-view-key {display: none;}`.

I suppose this patch does still not allow the user to reorder the items, though, unless some style directive allows for reordering the DOM tree. (?)
