### PR TITLE
Manually edit the triggers of cite and ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features
 Triggers:
   * Typing in `\ref{`, `\eqref{` or any control sequences that ends in `ref{`
   * Deleting anything so that the left of the cursor reads `\ref{`, `\eqref{`, and the like. E.g. deleting the word 'something' from `\pageref{something}`
+  * Custom Triggers can be added via settings
 
 ### Bibliography and citation autocompletion
 
@@ -29,9 +30,9 @@ Latexer will automatically scan your document to find your bibfiles. For example
 
 ##### LaTeX Triggers
 
-  * Typing in `\cite{`, `\citet{`, `\citet*{`, `\citep{`, `\citep*{`, or any control sequences that end in `cite{`. You can also write something in square brackets before, e.g. `\cite[Theorem 1]{`
+  * Typing in `\cite{`, `\citet{`, `\citet*{`, `\citep{`, `\citep*{`, or any control sequences that end in `cite{`. You can also write something in square brackets before, e.g. `\cite[Theorem 1]{` or `\cite[See:][Page 51-59]{`
   * Deleting anything so that the left of the cursor reads `\cite{`, `\textcite{`, `\citet{`, `\citet*{`, `\citep{` or `\citep*{`, e.g. deleting the word 'something' from `\cite{something}`
-  * Custom Triggers can be added via Settings
+  * Custom Triggers can be added via settings
 
 ##### [Pandoc-style Citation][1] Triggers
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Latexer will automatically scan your document to find your bibfiles. For example
 
 ##### LaTeX Triggers
 
-  * Typing in `\cite{`, `\textcite{`, `\citet{`, `\citet*{`, `\citep{` or `\citep*{`. You can also write something in square brackets before, e.g. `\cite[Theorem 1]{`.
+  * Typing in `\cite{`, `\citet{`, `\citet*{`, `\citep{`, `\citep*{`, or any control sequences that end in `cite{`. You can also write something in square brackets before, e.g. `\cite[Theorem 1]{`
   * Deleting anything so that the left of the cursor reads `\cite{`, `\textcite{`, `\citet{`, `\citet*{`, `\citep{` or `\citep*{`, e.g. deleting the word 'something' from `\cite{something}`
+  * Custom Triggers can be added via Settings
 
 ##### [Pandoc-style Citation][1] Triggers
 

--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -70,7 +70,7 @@ module.exports =
       if @oldCiteKeys != curKeys
         citeFilter = "\\\\\\w*("
         citeFilter += curKeys.join("|").replace(/\*/g, "\\*")
-        citeFilter += ")(\\[[^\\]]+\\])?({|{[^}]+,)$"
+        citeFilter += ")(\\[[^\\]]*\\]){0,2}({|{[^}]+,)$"
         @citeRex = RegExp(citeFilter)
         @oldCiteKeys = curKeys
 

--- a/lib/latexer.coffee
+++ b/lib/latexer.coffee
@@ -18,6 +18,12 @@ module.exports = Latexer =
       items:
         type: "string"
 
+    autocomplete_citations_by:
+      type: "array"
+      default: ["cite", "citet", "citep", "citet*", "citep*"]
+      items:
+        type: "string"
+
     autocomplete_environments:
       type: "boolean"
       default: true

--- a/lib/latexer.coffee
+++ b/lib/latexer.coffee
@@ -32,6 +32,12 @@ module.exports = Latexer =
       type: "boolean"
       default: true
 
+    autocomplete_references_by:
+      type: "array"
+      default: ["ref"]
+      items:
+        type: "string"
+
     autocomplete_citations:
       type: "boolean"
       default: true


### PR DESCRIPTION
As I have found myself needing this feature (which was already discussed in issue #25 for refs), I have implemented this for both ref and cite.
This is my first time writing coffescript code, so I hope it is acceptable, if not I will try to fix any issues.

I have furthermore changed the Regular Expression for the cite autocompletion, as commands with multiple brackets (pre & post) were not recognized, as well as empty pre or post fields. (see [Biblatex Cheat Sheet](http://tug.ctan.org/info/biblatex-cheatsheet/biblatex-cheatsheet.pdf))
Effectively this changes the regex to: 
`/\\\w*(cite|citet|citep|citet\*|citep\*)(\[[^\]]*\]){0,2}({|{[^}]+,)$/` 
instead of 
`/\\\w*(cite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/`