### PR TITLE
Add \nocite{} and \nocite*{} to citeRex

### DIFF
--- a/lib/latexer-hook.coffee
+++ b/lib/latexer-hook.coffee
@@ -8,7 +8,7 @@ module.exports =
     beginRex: /\\begin{([^}]+)}/
     mathRex: /(\\+)\[/
     refRex: /\\(\w*ref({|{[^}]+,)|[cC](page)?refrange({[^,}]*})?{)$/
-    citeRex: /\\\w*(cite|citet|citep|citet\*|citep\*)(\[[^\]]+\])?({|{[^}]+,)$/
+    citeRex: /\\\w*(cite|citet|citep|nocite|citet\*|citep\*|nocite\*)(\[[^\]]+\])?({|{[^}]+,)$/
     constructor: (@editor) ->
       @disposables = new CompositeDisposable
       @disposables.add @editor.onDidChangeTitle => @subscribeBuffer()


### PR DESCRIPTION
You can create invisible citations (they don't appear in the text, but in the references section) using `\nocite{}` and `\nocite*{}`. Latexer doesn't pick up on these and doesn't show the cite view.

This PR adds both keywords to the RegEx.